### PR TITLE
test: tolerate verifier preflight broken pipe

### DIFF
--- a/docs/agent-bridge/ACTION_LOG.md
+++ b/docs/agent-bridge/ACTION_LOG.md
@@ -720,3 +720,11 @@ Rules for all dev agents:
 - Direct HTTP 200 verification found the exact merged GH-63 markers in live README, Bridge, Whitepaper, Roadmap, and `llms.txt`. Scope estimates remain core 77-81%, complete vision 43-48%, and 52-57% remaining.
 - The next repository-owned product slice is the explicit bounded analyzer-domain adapter. Production proof-artifact approval/installation, real accepted-analysis evidence, two-host operation, H-001 external signing/execution, remaining deployments, metrics transition, PROM emission, and production nodes remain open.
 - No wallet, private key, secret, signature, raw transaction, broadcast, contract, Guardian/reporter authorization, reputation, KAS/PROM, slash ACL, commit-reveal behavior, emergency-stop policy, or foreign untracked file was accessed or changed. `Prometheus-1.png` remains untouched and uncommitted.
+
+## 2026-07-23 GH-69 verifier preflight test-race hardening
+
+- Exact-main Prometheus CI `29969343483` for the bridge reconciliation commit exposed a race in `unsafe_manifest_mode_is_unavailable`: the verifier correctly rejected the unsafe manifest before reading stdin, while the test helper incorrectly treated the resulting writer-side `BrokenPipe` as a verifier failure.
+- The shared runner remains strict for every normal verification path. A separate explicit preflight-exit helper tolerates only `ErrorKind::BrokenPipe`, after which the test still requires exit 3 and silent stdout/stderr.
+- Local verification passes 50 consecutive repetitions of the affected preflight test, all 7 threat-proof tests, focused warning-free Clippy, Rustfmt, Memory Integrity, and the complete 247-test workspace with two intentional live-network ignores.
+- Production manifest ownership/mode validation, proof verification, CLI exit semantics, and fail-closed operation are unchanged. Issue #69 tracks the CI stabilization through the protected workflow.
+- No wallet, private key, secret, signature, raw transaction, broadcast, contract, Guardian/reporter authorization, reputation, KAS/PROM, slash ACL, commit-reveal behavior, emergency-stop policy, or foreign untracked file was accessed or changed. `Prometheus-1.png` remains untouched and uncommitted.

--- a/modules/threat-proof/tests/verifier_cli.rs
+++ b/modules/threat-proof/tests/verifier_cli.rs
@@ -142,6 +142,25 @@ fn secure_write(path: &Path, bytes: &[u8]) {
 }
 
 fn run(fixture: &Fixture, wire: &[u8], network: &str, expected_hash: &str) -> Output {
+    run_with_stdin_policy(fixture, wire, network, expected_hash, false)
+}
+
+fn run_allowing_preflight_exit(
+    fixture: &Fixture,
+    wire: &[u8],
+    network: &str,
+    expected_hash: &str,
+) -> Output {
+    run_with_stdin_policy(fixture, wire, network, expected_hash, true)
+}
+
+fn run_with_stdin_policy(
+    fixture: &Fixture,
+    wire: &[u8],
+    network: &str,
+    expected_hash: &str,
+    allow_preflight_exit: bool,
+) -> Output {
     let mut child = Command::new(env!("CARGO_BIN_EXE_prometheus-threat-proof"))
         .args([
             "verify",
@@ -157,12 +176,12 @@ fn run(fixture: &Fixture, wire: &[u8], network: &str, expected_hash: &str) -> Ou
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn verifier");
-    child
-        .stdin
-        .take()
-        .expect("child stdin")
-        .write_all(wire)
-        .expect("write wire");
+    let write_result = child.stdin.take().expect("child stdin").write_all(wire);
+    match write_result {
+        Ok(()) => {}
+        Err(error) if allow_preflight_exit && error.kind() == std::io::ErrorKind::BrokenPipe => {}
+        Err(error) => panic!("write wire: {error}"),
+    }
     child.wait_with_output().expect("wait for verifier")
 }
 
@@ -257,17 +276,15 @@ fn unsafe_manifest_mode_is_unavailable() {
     let fixture = fixture();
     fs::set_permissions(&fixture.manifest_path, fs::Permissions::from_mode(0o644))
         .expect("make manifest unsafe");
-    assert_eq!(
-        run(
-            &fixture,
-            &fixture.wire,
-            "testnet-10",
-            &fixture.manifest_sha256
-        )
-        .status
-        .code(),
-        Some(3)
+    let output = run_allowing_preflight_exit(
+        &fixture,
+        &fixture.wire,
+        "testnet-10",
+        &fixture.manifest_sha256,
     );
+    assert_eq!(output.status.code(), Some(3));
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- keep normal verifier stdin writes strict
- permit `BrokenPipe` only when an explicit preflight-rejection test allows the verifier to exit before consuming stdin
- retain exit-3 and silent-output assertions for unsafe manifests
- record the exact-main CI race and local stress evidence

## Verification

- affected test passes 50 consecutive runs
- all 7 threat-proof tests pass
- complete workspace passes: 247 tests, 2 intentional live-network ignores
- Rustfmt, focused warning-free Clippy, Memory Integrity, and diff checks pass

Production manifest validation and verifier behavior are unchanged.

Closes #69