### PR TITLE
fix: remediate RUSTSEC-2026-0220

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4418,9 +4418,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "borsh",
  "proptest",

--- a/docs/agent-bridge/ACTION_LOG.md
+++ b/docs/agent-bridge/ACTION_LOG.md
@@ -2448,3 +2448,42 @@ Rules for all dev agents:
 - **Status:** `Done / Exact-main and live Pages verified`.
 
 `TASK COMPLETE - TARGET STOP ACTIVE`
+
+### 2026-07-31 13:16 EEST - Dependency security fix opened
+
+- Started `GIO-PROM-20260731-RUINT` and GitHub issue
+  [#127](https://github.com/NeaBouli/prometheus-/issues/127) from exact main
+  `0b0b743`.
+- Root cause: `RUSTSEC-2026-0220` affects transitive `ruint 1.19.0` through
+  `risc0-binfmt -> kaspa-txscript`, including the deployment-operator graph.
+- Planned remediation is the minimum safe lockfile update to `ruint >=1.20.0`
+  with full audit and Rust integration evidence.
+- No advisory suppression, workflow change, protocol change, production,
+  wallet, signing, broadcast, deployment, or chain action.
+- **Status:** `In Progress`.
+
+### 2026-07-31 14:14 EEST - Local security verification PASS
+
+- Final Cargo diff is only `ruint 1.19.0 -> 1.20.0`; targeted lockfile
+  re-resolution removed an unrelated `syn` edge identified as P2 by Terra.
+- Audit: zero vulnerabilities, eight unchanged allowed warnings; old `ruint`
+  absent and the safe version present throughout the Kaspa operator path.
+- PASS: Rustfmt, Memory Integrity, 55 current-SilverC fixture tests, 49 focused
+  deployer tests, 346 workspace tests with two intentional live ignores, and
+  warning-free workspace all-target Clippy.
+- Corrected environment events: generated targets from an isolated prior
+  worktree were cleaned after a disk-full stop. One response-channel race test
+  then failed once, passed five focused repetitions, and passed in the complete
+  rerun; no unrelated source edit was introduced.
+- Kimi quota remains exhausted. Terra targeted re-review is pending.
+- **Status:** `Local PASS / Review pending`.
+
+### 2026-07-31 14:16 EEST - Security candidate approved
+
+- Terra targeted re-review: PASS, no P0/P1/P2; unrelated lockfile churn is
+  absent and only the safe `ruint` version/checksum changed.
+- Final locked metadata/tree checks, diff check, and redacted Gitleaks 8.30.1
+  scan of the complete 5.58-KB diff pass with zero findings.
+- Exact publication set: `Cargo.lock`, `docs/agent-bridge/ACTION_LOG.md`, and
+  `docs/agent-bridge/CODEX_BRIDGE.md`.
+- **Status:** `Approved locally / Protected PR next`.

--- a/docs/agent-bridge/ACTION_LOG.md
+++ b/docs/agent-bridge/ACTION_LOG.md
@@ -2487,3 +2487,11 @@ Rules for all dev agents:
 - Exact publication set: `Cargo.lock`, `docs/agent-bridge/ACTION_LOG.md`, and
   `docs/agent-bridge/CODEX_BRIDGE.md`.
 - **Status:** `Approved locally / Protected PR next`.
+
+### 2026-07-31 14:18 EEST - Issue #127 candidate published
+
+- Committed the exact three-file security candidate as `db8adba`.
+- Pushed `fix/ruint-rustsec-2026-0220` and opened protected PR
+  [#128](https://github.com/NeaBouli/prometheus-/pull/128), closing #127 only
+  after a normal protected merge.
+- **Status:** `In Progress / Exact-head CI and review`.

--- a/docs/agent-bridge/CODEX_BRIDGE.md
+++ b/docs/agent-bridge/CODEX_BRIDGE.md
@@ -2130,3 +2130,13 @@ No direct `main` push or production action occurred.
 - **Status:** `Approved locally / Ready for protected publication`.
 - **Next:** commit the exact three-file set, push the issue #127 branch, open a
   protected PR, and require exact-head CI/Security/review before merge.
+
+### 2026-07-31 14:18 EEST - RUSTSEC protected PR opened
+
+- Commit `db8adba` contains the exact reviewed three-file candidate.
+- Branch `fix/ruint-rustsec-2026-0220` is pushed and protected PR
+  [#128](https://github.com/NeaBouli/prometheus-/pull/128) targets `main` and
+  closes issue #127 only on merge.
+- No direct main push, bypass, workflow weakening, production, wallet,
+  signing, broadcast, deployment, or chain action occurred.
+- **Status:** `In Progress / Exact-head CI and review`.

--- a/docs/agent-bridge/CODEX_BRIDGE.md
+++ b/docs/agent-bridge/CODEX_BRIDGE.md
@@ -2068,3 +2068,65 @@ No direct `main` push or production action occurred.
   outside GH-121/GH-123.
 
 `TASK COMPLETE - TARGET STOP ACTIVE`
+
+### 2026-07-31 13:16 EEST - RUSTSEC-2026-0220 remediation started
+
+- Ticket `GIO-PROM-20260731-RUINT` and GitHub issue
+  [#127](https://github.com/NeaBouli/prometheus-/issues/127) own a separate
+  dependency-security fix from exact main
+  `0b0b74335024ee21cd87b83e18cbe1663dbd1065`.
+- PR #126 exposed a real `cargo audit` failure:
+  `ruint 1.19.0` is affected by `RUSTSEC-2026-0220`; the safe range starts at
+  `1.20.0`. The dependency enters through
+  `risc0-binfmt -> kaspa-txscript` and reaches the client, validator, and
+  SilverC deployment operator.
+- Scope is limited to the smallest compatible dependency upgrade, proof that
+  the advisory is absent, complete relevant Rust validation, independent
+  review, and a protected GitHub PR.
+- No audit ignore, workflow weakening, product/protocol change, direct main
+  push, wallet access, signing, broadcast, deployment, or chain mutation is
+  allowed.
+- **Status:** `In Progress / Dependency remediation`.
+- **Next:** update the lockfile to the minimum safe compatible release, inspect
+  the exact diff and dependency tree, then run audit, format, tests, Clippy,
+  and H-001 operator regression checks.
+
+### 2026-07-31 14:14 EEST - RUSTSEC remediation locally validated
+
+- The final lockfile diff contains only `ruint 1.19.0 -> 1.20.0` and its
+  registry checksum. A first Cargo resolution also moved an unrelated
+  `data-encoding-macro-internal` `syn` edge; Terra correctly marked that P2,
+  and a targeted package re-resolution removed the churn while preserving a
+  locked offline metadata pass.
+- `cargo audit` now reports zero vulnerabilities and the eight unchanged,
+  already allowed warnings. `ruint 1.19.0` is absent; `1.20.0` serves the
+  complete `risc0-binfmt -> kaspa-txscript` client, validator, and operator
+  path.
+- Rustfmt, Memory Integrity, H-001/current-SilverC 55-test fixture
+  verification, 49 focused operator tests, 346 complete workspace tests with
+  two intentional live-network ignores, and warning-free workspace all-target
+  Clippy pass.
+- The first complete workspace run was environment-blocked by a full disk.
+  Sol removed only generated Cargo targets from the isolated prior worktree.
+  The next run exposed one Guardian response-channel timing failure; that exact
+  test passed five consecutive focused runs and then passed in the complete
+  workspace rerun. No Guardian source change was made.
+- Kimi review remained unavailable because its external monthly quota is
+  exhausted. Terra's initial P2 is remediated; targeted re-review is pending.
+- **Status:** `Local PASS / Independent re-review pending`.
+- **Next:** obtain the targeted re-review, run final diff/leak checks, then
+  publish issue #127 through a protected PR and require exact-head CI/Security.
+
+### 2026-07-31 14:16 EEST - RUSTSEC candidate independently approved
+
+- Terra targeted re-review: PASS, no remaining P0/P1/P2. The former `syn`
+  lockfile P2 is closed and the `data-encoding-macro-internal` block is
+  byte-identical to `origin/main`.
+- Locked online/offline metadata and dependency-tree checks pass. The final
+  complete diff is limited to the intended `ruint` version/checksum update and
+  append-only Bridge evidence.
+- Final diff check and redacted Gitleaks 8.30.1 stdin scan over the complete
+  5.58-KB diff pass with zero findings.
+- **Status:** `Approved locally / Ready for protected publication`.
+- **Next:** commit the exact three-file set, push the issue #127 branch, open a
+  protected PR, and require exact-head CI/Security/review before merge.


### PR DESCRIPTION
## Summary

- update transitive `ruint` from 1.19.0 to the minimum safe 1.20.0 release
- remove `RUSTSEC-2026-0220` without suppressing the advisory or weakening CI
- record append-only security and validation evidence

## Validation

- `cargo audit`: zero vulnerabilities; eight unchanged allowed warnings
- `cargo test -p prometheus-silverc-deployer --locked`: 49 passed
- `cargo test --workspace --all-targets --locked`: 346 passed, 2 intentional live-network ignores
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: passed
- `cargo fmt --all -- --check`: passed
- current-SilverC/H-001 fixture verification: 55 passed
- Memory Integrity, locked offline metadata/tree, diff check, and Gitleaks: passed
- independent Terra re-review: no remaining P0/P1/P2

## Boundaries

No protocol, contract, commit-reveal, staking, reward, workflow-policy, wallet, signing, broadcast, deployment, or chain-state change.

Closes #127