### PR TITLE
docs: close GH-173 bridge audit trail

### DIFF
--- a/docs/agent-bridge/ACTION_LOG.md
+++ b/docs/agent-bridge/ACTION_LOG.md
@@ -3629,3 +3629,16 @@ Rules for all dev agents:
   pass. Current public/internal status surfaces now record that evidence without
   changing readiness percentages or production authority.
 - Status: `Done / Exact-main verified / Docs closeout local PASS next`.
+
+## 2026-08-13 03:39 EEST - GH-173 public documentation closeout
+
+- Documentation PR #175 merged as exact main `619374e`; its remote branch was
+  deleted.
+- Final-closeout CI `31654905321`, Security `31654905397`, and Pages
+  `31654904489` pass on the exact merge commit.
+- Cache-busted live Pages and commit-pinned raw README readback confirm the
+  merged GH-173 status and feature commit `1107b11` across all public status
+  surfaces.
+- This append-only record changes documentation only. No external runtime,
+  wallet, chain, deployment or production action occurred.
+- Status: `Done / Public docs and exact-main closeout verified`.

--- a/docs/agent-bridge/CODEX_BRIDGE.md
+++ b/docs/agent-bridge/CODEX_BRIDGE.md
@@ -3910,3 +3910,17 @@ No direct `main` push or production action occurred.
 - No product behavior, rollout estimate, model, scan, submission, disclosure,
   wallet, signing, chain, reward, deployment or production authority changed.
 - **Status:** `GH-173 Done / Exact-main verified / Docs closeout local candidate`.
+
+### 2026-08-13 03:39 EEST - GH-173 public documentation closeout verified
+
+- Documentation-only PR #175 merged normally as exact main
+  `619374e311ae3a047af025b954d9b3eb52e5a077`; its remote branch is deleted.
+- Final-closeout Prometheus CI `31654905321`, Security Audit `31654905397`,
+  and Pages `31654904489` all completed successfully on that exact commit.
+- Cache-busted live readback confirms the GH-173 status and feature commit
+  `1107b11` on the homepage, Whitepaper, Roadmap, FAQ and `llms.txt`; the raw
+  commit-pinned README confirms the same merged and exact-main-verified status.
+- The repository was clean and synchronized with `origin/main` before this
+  append-only audit record. No product behavior, readiness estimate, wallet,
+  signing, chain, deployment or production authority changed.
+- **Status:** `GH-173 Done / Public docs and exact-main closeout verified`.


### PR DESCRIPTION
## Summary
- append final PR #175 exact-main workflow evidence to the project Bridge
- record cache-busted public Pages and commit-pinned README readback
- preserve the append-only GH-173 audit trail

## Verification
- `git diff --check`
- `python3 scripts/check_memory_integrity.py`
- `python3 -m unittest scripts.test_autodidactic`

Documentation-only. No product, wallet, chain, deployment, or production action.