### PR TITLE
fix: make Python dependency audit fail closed

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -73,20 +73,28 @@ jobs:
         run: cargo audit
         timeout-minutes: 10
 
-      - name: Check for requirements.txt
-        id: check-pip
+      - name: pip audit
         run: |
-          if [ -f requirements.txt ] || find . -maxdepth 3 -name "requirements.txt" -print -quit | grep -q .; then
-            echo "has_pip=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_pip=false" >> $GITHUB_OUTPUT
+          manifest_list="${RUNNER_TEMP}/prometheus-python-dependency-manifests"
+          git ls-files -z -- \
+            ':(glob)requirements*.txt' \
+            ':(glob)**/requirements*.txt' \
+            ':(glob)constraints*.txt' \
+            ':(glob)**/constraints*.txt' > "${manifest_list}"
+          if [ ! -s "${manifest_list}" ]; then
+            echo "No tracked Python dependency manifests found."
+            exit 0
           fi
 
-      - name: pip audit
-        if: steps.check-pip.outputs.has_pip == 'true'
-        run: |
           python -m pip install pip-audit==2.10.1
-          find . -maxdepth 3 -name "requirements.txt" -exec pip-audit -r {} \;
+          status=0
+          while IFS= read -r -d '' manifest; do
+            echo "Auditing ${manifest}"
+            if ! python -m pip_audit -r "${manifest}"; then
+              status=1
+            fi
+          done < "${manifest_list}"
+          exit "${status}"
         timeout-minutes: 10
 
   security-summary:

--- a/docs/agent-bridge/CODEX_BRIDGE.md
+++ b/docs/agent-bridge/CODEX_BRIDGE.md
@@ -4155,3 +4155,35 @@ No direct `main` push or production action occurred.
   production-deployed, and rollout estimates remain core 84-88% / complete
   vision 50-55%.
 - **Status:** `GH-180 Docs closeout local PASS / Protected docs PR next`.
+
+### 2026-08-13 14:36 EEST - Python dependency audit fail-closed fix started
+
+- A secret-free static review and an independent Kimi K3 review confirmed that
+  the current multi-manifest `pip-audit` shell command does not propagate a
+  failing child audit to the workflow exit status.
+- Scope is limited to the Security Audit workflow: discover tracked Python
+  requirement/constraint manifests deterministically, audit every discovered
+  file, and return nonzero if any audit fails. No dependency version, product
+  code, public finding detail, production system or external PR is changed.
+- Sol owns the patch and complete validation. Kimi's contribution is read-only;
+  it changed no files and reported generic CI/documentation hardening only.
+- **Status:** `SEC-CI-1 In Progress / Local workflow fix next`.
+
+### 2026-08-13 15:08 EEST - SEC-CI-1 local verification PASS
+
+- Replaced the non-propagating multi-file `find -exec` audit with one
+  deterministic tracked-manifest list in `RUNNER_TEMP`. A failed discovery now
+  fails under the Actions shell, an empty list exits cleanly, every listed
+  manifest is audited, and any failed audit produces final exit status 1.
+- PASS: mixed root/nested fixture audited 2/2 and returned 1 after one simulated
+  failure; current repository success fixture audited 1/1 and returned 0;
+  empty-repository fixture returned the expected no-manifest path; workflow
+  YAML parsed; `git diff --check`; all eight Memory Integrity checks.
+- Kimi K3's independent read-only diff review found no P0/P1/P2 and approved
+  the fail-closed semantics under GitHub Actions bash. Sol accepted its
+  theoretical process-substitution P3 by materializing the list before the
+  loop; the exact real `pip-audit==2.10.1` run remains for protected CI because
+  the tool is not installed in the local environment.
+- No dependency versions, product code, public finding details, infrastructure,
+  production systems or external GitHub state changed.
+- **Status:** `SEC-CI-1 Complete local PASS / Commit and protected PR pending`.


### PR DESCRIPTION
## Summary
- discover tracked Python requirement and constraint manifests deterministically
- audit every discovered manifest
- fail the Security Audit workflow if any Python dependency audit fails

## Validation
- mixed root/nested fixture: 2/2 audited, one simulated failure propagated
- current repository fixture: 1/1 success
- empty manifest fixture: clean no-op
- workflow YAML parse, git diff check, Memory Integrity pass
- independent read-only Kimi review: no P0/P1/P2

## Boundaries
Repository-only CI hardening. No dependency versions, product code, public finding detail, production system, infrastructure, secret, key, deployment, or audit PR #183 change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security audits to discover and check all tracked Python dependency manifests.
  * Audits each manifest independently and reports failures reliably.
  * Handles repositories without dependency manifests successfully while failing closed on discovery errors.

* **Documentation**
  * Added a status record documenting the security audit improvements and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->