### PR TITLE
docs: record public claim reconciliation closeout

### DIFF
--- a/docs/agent-bridge/ACTION_LOG.md
+++ b/docs/agent-bridge/ACTION_LOG.md
@@ -3838,3 +3838,15 @@ Rules for all dev agents:
   `docs/claim-audit-2026-08-14.md`. Local Actionlint and Gitleaks are absent and
   remain mandatory protected contexts before merge.
 - Status: `Local PASS / Commit and protected PR next`.
+
+## 2026-08-14 - Public claim reconciliation protected merge closeout
+
+- PR #188 passed all eleven attached contexts at exact head `66bdac0` with no
+  review threads and merged normally as `5416b49`; issue #187 closed.
+- Exact-main CI `31751277505`, Security `31751277513`, and Pages `31751277037`
+  pass. Five cache-busted live Pages and the commit-pinned README expose the
+  reconciled status markers.
+- Production and private-audit gates remain blocked/open as documented. This
+  closeout records evidence only and performs no product or external runtime
+  action.
+- Status: `Done / Exact-main and live Pages verified`.

--- a/docs/agent-bridge/CODEX_BRIDGE.md
+++ b/docs/agent-bridge/CODEX_BRIDGE.md
@@ -4258,3 +4258,24 @@ No direct `main` push or production action occurred.
   remain required. No direct-main push, production action, audit-detail
   disclosure, wallet/chain action, or security-policy change occurred.
 - **Status:** `PROMETHEUS-DOC-CLAIMS-20260814 Local PASS / Commit and protected PR next`.
+
+## 2026-08-14 - Public claim reconciliation merged and exact-main verified
+
+- PR #188 passed all eleven attached protected contexts at exact reviewed head
+  `66bdac0d56e7c891235c4b88884be015cd706e0a`; CodeRabbit was rate-limited but
+  its required context passed, and the PR had zero review threads.
+- PR #188 squash-merged normally without admin bypass as exact main
+  `5416b493ad24c2733f50add5bd76825e2e83a433`; issue #187 is closed and the
+  remote feature branch was deleted.
+- Exact-main Prometheus CI `31751277505`, Security Audit `31751277513`, and
+  Pages `31751277037` pass. The HTML Pages job exercised the new synchronized
+  public-claims gate; hosted `index`, Whitepaper, FAQ, Roadmap and Guardian
+  economics pages plus the commit-pinned README expose the reconciled markers.
+- Public status now distinguishes development/test evidence, the one
+  non-promotable Testnet-10 canary, no proven production protocol deployment,
+  planned target architecture, and blocked/unproven gates. The private-operator
+  audit release gate and every production rollout gate remain active.
+- No product code, contract behavior, tokenomics, security policy, wallet,
+  chain, deployment, infrastructure, secret, private audit detail, direct-main
+  push, admin bypass, or destructive Git action occurred.
+- **Status:** `PROMETHEUS-DOC-CLAIMS-20260814 Done / Exact-main and live Pages verified`.


### PR DESCRIPTION
## Summary
- append PR #188 merge and exact-main CI/Security/Pages evidence to the project Bridge and Action Log
- record live Pages and commit-pinned README verification
- preserve all production and private-audit release gates

Documentation evidence only; no product or external runtime action.