### PR TITLE
docs: finalize GH-197 handoff status

### DIFF
--- a/docs/agent-bridge/ACTION_LOG.md
+++ b/docs/agent-bridge/ACTION_LOG.md
@@ -3980,3 +3980,14 @@ Rules for all dev agents:
 - Started documentation-only issue #199 and branch
   `docs/GH-199-gh197-closeout`.
 - Status: `GH-197 exact-main verified / Documentation closeout in progress / Production false`.
+
+## 2026-08-15 - GH-201 final status synchronization
+
+- Confirmed PR #200 merged normally as exact documentation main `a9e987c` and
+  issue #199 is closed.
+- Confirmed exact-main CI `31904938024`, Security `31904938123`, and Pages
+  `31904937253` pass.
+- Replaced stale task-current GH-199 `in progress` wording in the checkpoint
+  and appended a self-finalizing repository handoff. No public claim or product
+  behavior changed.
+- Status: `GH-197 Done / GH-199 Done / GH-201 Done on normal merge / Production false`.

--- a/docs/agent-bridge/CODEX_BRIDGE.md
+++ b/docs/agent-bridge/CODEX_BRIDGE.md
@@ -4519,3 +4519,30 @@ No direct `main` push or production action occurred.
   evidence synchronization. No product, wallet, chain, deployment, contract,
   tokenomics or security-policy behavior changes.
 - **Status:** `GH-197 Merged and exact-main verified / GH-199 closeout in progress / Production false`.
+
+## 2026-08-15 - GH-201 final status synchronization started
+
+- Documentation PR #200 merged normally as exact main
+  `a9e987c28a1984fe0f89a10991f7021253ed486a`, closing issue #199.
+- Exact-main Prometheus CI `31904938024`, Security Audit `31904938123`, and
+  Pages `31904937253` pass. Security includes Gitleaks, documentation hygiene,
+  Cargo audit, and Python dependency audit.
+- Issue #201 and branch `docs/GH-201-gh197-final-status` own the final removal
+  of stale task-current `in progress` wording. This is documentation-only and
+  changes no product behavior or public technical claim.
+- **Status:** `GH-197 and GH-199 Done / GH-201 status sync in progress / Production false`.
+
+## 2026-08-15 - GH-201 final repository handoff
+
+- GH-197 product PR #198 is merged and exact-main verified at `28da2d4`.
+- GH-199 documentation PR #200 is merged and exact-main verified at
+  `a9e987c`; CI `31904938024`, Security `31904938123`, and Pages
+  `31904937253` all pass.
+- GH-201 changes only task-current handoff metadata in `memory/CHECKPOINT.md`,
+  this append-only Bridge, and `docs/agent-bridge/ACTION_LOG.md`. It does not
+  change public claims or product behavior.
+- This entry becomes final when the normal protected GH-201 pull request is
+  merged. It intentionally needs no recursive task-local exact-SHA annotation;
+  final merge and exact-main workflow evidence is retained in GitHub and the
+  private cross-project Bridge.
+- **Status:** `GH-197 Done / GH-199 Done / GH-201 Done on normal merge / Production false`.

--- a/memory/CHECKPOINT.md
+++ b/memory/CHECKPOINT.md
@@ -13,10 +13,10 @@
 | Repo | https://github.com/NeaBouli/prometheus- |
 | Branch | Canonical target `main`; product/public/status changes remain PR-only |
 | Lokaler Pfad | `$REPO_ROOT` |
-| Letzter grün verifizierter Produkt-/Public-Baseline | Exact product/public main `28da2d42f85233395c38d633f799befba0223797`; Prometheus CI `31904377606`, Security `31904377632`, and Pages `31904376972` pass |
-| Aktueller Entwicklungs-Slice | GH-197/PR #198 is merged and exact-main verified; GH-199 documentation-only evidence closeout is in progress |
+| Letzter grün verifizierter Produkt-/Public-Baseline | Exact product main `28da2d42f85233395c38d633f799befba0223797` and exact documentation main `a9e987c28a1984fe0f89a10991f7021253ed486a`; latest Prometheus CI `31904938024`, Security `31904938123`, and Pages `31904937253` pass |
+| Aktueller Entwicklungs-Slice | GH-197 product work and GH-199 documentation closeout are complete; GH-201 only finalizes the task-current handoff wording and selects no new feature scope |
 | Aktuelle Tooling-Baseline | H-001 Testnet-10 signature/import/full verification/one-shot broadcast/confirmation/receipt/independent evidence and repository-public hash revalidation pass on exact main. The bounded GH-167 ThreatHint-v2 repository transport substrate is merged and exact-main verified. Production proof artifacts/ceremony, independent cryptographic/privacy review, real semantic/actionable analysis, six state deployments, metrics-oracle evidence, operated multi-host transport, and rollout remain open. |
-| Aktueller HEAD | Documentation branch `docs/GH-199-gh197-closeout` from exact feature main `28da2d42f85233395c38d633f799befba0223797`; product behavior is unchanged |
+| Aktueller HEAD | Canonical target `main`; GH-197 product and GH-199 evidence closeout are merged, with no active product feature branch |
 | Rollback-Tag | `pre-session-20260413` → `6347b85` |
 | Whitepaper | WHITEPAPER.md (root) + whitepaper.html (styled); GH-197 is merged/exact-main synchronized as a consistency-only development boundary without chain-truth, finality, or production claims |
 | Status | H-001 Testnet-10 canary is confirmed and independently evidenced. Rollout-capable core is estimated at 84-88%. GH-167 closes only the bounded repository v2 transport substrate. Production relation/key/ceremony approval and independent cryptographic/privacy review, real semantic/actionable analysis, six state deployments, metrics-oracle evidence, operated multi-host transport, crash-safe external side effects, and full rollout evidence remain gated. |


### PR DESCRIPTION
Closes #201.

## Summary
- marks GH-197 product work and GH-199 documentation closeout complete in the current checkpoint
- records PR #200 exact-main CI, Security, and Pages evidence
- adds a self-finalizing append-only handoff so no recursive task-local evidence PR is needed

## Verification
- `python3 scripts/verify_public_claim_consistency.py` — PASS, 13 surfaces
- `python3 -m unittest scripts/test_public_claim_consistency.py` — 6 passed
- `python3 scripts/check_public_documentation_hygiene.py` — PASS
- `python3 -m unittest scripts/test_public_documentation_hygiene.py` — 11 passed
- `python3 scripts/verify_h001_canary_closeout_evidence.py` — PASS
- `python3 -m unittest scripts/test_h001_canary_closeout_evidence.py` — 4 passed
- `git diff --check` — PASS

## Boundaries
Documentation/status only. No product code, public technical claim, architecture, contract, tokenomics, wallet, chain, deployment, or security-policy change.